### PR TITLE
Add Himalaya email CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     uv tool install mcp-server-time --python-preference managed && \
     uv tool install mcp-server-fetch --python-preference managed
 
+# Install Himalaya CLI (email client)
+RUN curl -sSL https://github.com/pimalaya/himalaya/releases/latest/download/himalaya.x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin/ && \
+    chmod +x /usr/local/bin/himalaya
+
 # Add supervisord config and entrypoint script
 COPY docker/supervisord.conf /etc/supervisor/conf.d/openclaw.conf
 COPY docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary
- Adds [Himalaya](https://github.com/pimalaya/himalaya) CLI email client to the Docker image
- Needed for Léa to read/send emails via Gmail

## Changes
- Downloads latest Himalaya release (x86_64 linux) and installs to `/usr/local/bin/`

## Test plan
- [ ] Rebuild the Docker image
- [ ] Verify `himalaya --version` works inside the container
- [ ] Test email access with Léa

🤖 Generated with [Claude Code](https://claude.com/claude-code)