### PR TITLE
Build Himalaya with OAuth2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+# Build Himalaya with OAuth2 support (pre-built binaries don't include it)
+FROM rust:1-bookworm AS himalaya-builder
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pkg-config libssl-dev && \
+    cargo install himalaya --locked --features oauth2 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM node:24
 
 # Install supervisor for process management and openssh-server for optional SSH access
@@ -27,8 +34,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     uv tool install mcp-server-time --python-preference managed && \
     uv tool install mcp-server-fetch --python-preference managed
 
-# Install Himalaya CLI (email client)
-RUN curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sh
+# Copy Himalaya binary with OAuth2 support from builder stage
+COPY --from=himalaya-builder /usr/local/cargo/bin/himalaya /usr/local/bin/himalaya
 
 # Add supervisord config and entrypoint script
 COPY docker/supervisord.conf /etc/supervisor/conf.d/openclaw.conf


### PR DESCRIPTION
## Summary
- Pre-built Himalaya binary doesn't include `oauth2` cargo feature
- Gmail OAuth2 authentication fails with `missing oauth2 cargo feature` error
- Compiles Himalaya from source with `--features oauth2`
- Removes Rust toolchain after build to keep image clean

## Context
Current error when using OAuth2 config:
```
TOML parse error at line 7, column 1
backend.type = "imap"
  ^^^^^^^ missing `oauth2` cargo feature
```

## Test plan
- [ ] Docker build completes successfully
- [ ] `himalaya --version` shows `+oauth2` in feature list
- [ ] Gmail OAuth2 authentication works

🤖 Generated with [Claude Code](https://claude.com/claude-code)