### PR TITLE
Run user boot script on container start

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -148,4 +148,11 @@ if [ ! -f "$CONFIG_FILE" ] && [ "${OPENCLAW_SKIP_ONBOARD:-false}" != "true" ]; t
   fi
 fi
 
+# Run user boot script if present (restores symlinks, config, etc.)
+BOOT_SCRIPT="$HOME/.openclaw/boot-setup.sh"
+if [ -x "$BOOT_SCRIPT" ]; then
+  echo "==> Running user boot script..."
+  runuser -u node -- "$BOOT_SCRIPT"
+fi
+
 exec "$@"


### PR DESCRIPTION
## Summary
- Executes `~/.openclaw/boot-setup.sh` on container start if present
- Allows restoring symlinks and config lost on Docker rebuild
- Runs as `node` user, no-op if script doesn't exist

## Use case
Tools like Himalaya store config in `~/.config/` which is not persisted across rebuilds. With this, users put a boot script in the persistent volume (`~/.openclaw/`) that recreates symlinks:

```bash
#!/bin/bash
mkdir -p ~/.config
ln -sf ~/.openclaw/config-backup/himalaya ~/.config/himalaya
```

## Test plan
- [ ] Container starts normally without boot script (no error)
- [ ] Container runs boot script when present and executable
- [ ] Himalaya config survives a rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)