### PR TITLE
Fix permissions on mounted .config volume

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,13 +29,15 @@ export HOME=/home/node
 CONFIG_FILE="$HOME/.openclaw/openclaw.json"
 mkdir -p "$HOME/.openclaw"
 
-# Fix ownership on data directory BEFORE setup so node user can write
+# Fix ownership on mounted volumes BEFORE setup so node user can write
 if [ "$(id -u)" = "0" ]; then
   chown -R node:node "$HOME/.openclaw" || {
     echo "Error: Could not set permissions on data directory." >&2
     echo "Run 'sudo chown -R 1000:1000 ./data' on the host." >&2
     exit 1
   }
+  # Also fix .config if mounted as volume (used by himalaya, etc.)
+  [ -d "$HOME/.config" ] && chown -R node:node "$HOME/.config"
 fi
 
 # Set defaults


### PR DESCRIPTION
## Summary
- `~/.config` mounted as volume has `root:root` ownership
- `node` user can't write → Himalaya can't create config
- Adds `chown -R node:node ~/.config` alongside existing `.openclaw` chown

## One-line change
```bash
[ -d "$HOME/.config" ] && chown -R node:node "$HOME/.config"
```

## Test plan
- [ ] `touch ~/.config/test` works as node user after container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)