### PR TITLE
feat: add QMD search engine for agent memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,14 @@ RUN npm install -g \
     @upstash/context7-mcp \
     open-meteo-mcp-server
 
+# Install QMD-Go (hybrid search engine for agent memory)
+# Single binary, no CGO, no native deps. Uses Bifrost/Titan for embeddings.
+# https://github.com/alexei-led/qmd-go
+ARG QMD_VERSION=v0.0.1
+RUN curl -fsSL -o /usr/local/bin/qmd \
+      "https://github.com/alexei-led/qmd-go/releases/download/${QMD_VERSION}/qmd-linux-amd64" && \
+    chmod +x /usr/local/bin/qmd
+
 # Environment setup — set HOME before uv tool install so Python-based
 # MCP servers install into /home/node/.local/bin (survives container rebuild
 # when /home/node is a mounted volume)


### PR DESCRIPTION
## What

Add [alexei-led/qmd-go](https://github.com/alexei-led/qmd-go) to Léa's Docker image — a single Go binary for hybrid markdown search.

## Why

Léa's current `memory_search` has poor recall. QMD provides hybrid BM25 + vector search that dramatically improves memory retrieval. The Go rewrite solves all the issues we hit with the Node.js version:

| | Node.js qmd | **qmd-go** ✅ |
|---|---|---|
| Install | npm + gcc/g++/make + better-sqlite3 compile | `curl` + `chmod +x` |
| Image cost | ~200MB (build tools + node_modules) | **~15MB** (single binary) |
| CGO / native deps | Segfaults on Node 25 (ABI mismatch) | No CGO (SQLite via WASM) |
| Remote embeddings | ❌ Local GGUF only | ✅ OpenAI-compatible API (→ Bifrost/Titan) |
| OpenClaw integration | ❌ None | ✅ Built-in sidecar mode (`qmd mcp --openclaw`) |
| Concurrent access | ❌ Single-threaded, crashes | ✅ Goroutines + connection pool |

## Tested locally

```
$ qmd-go status
Index:       default
Documents:   159 active / 159 total
Collections: memory (120 files), contacts (39 files)

$ qmd-go search 'voyage USA 2026'
[0.7939] memory/voyage-usa-2026.md
[0.7916] contacts/famille.md
[0.7915] memory/contacts/famille.md
...
```

BM25 search works instantly. Next step: configure Bifrost/Titan embeddings for semantic search.

## Dockerfile change

Just 4 lines — download the binary:
```dockerfile
ARG QMD_VERSION=v0.0.1
RUN curl -fsSL -o /usr/local/bin/qmd \
      "https://github.com/alexei-led/qmd-go/releases/download/${QMD_VERSION}/qmd-linux-amd64" && \
    chmod +x /usr/local/bin/qmd
```