### PR TITLE
feat: add Go 1.24 toolchain + build-essential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,18 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     mkdir -p /run/sshd
 
+# Install Go toolchain + C compiler (needed for CGo/SQLite)
+ARG GO_VERSION=1.24.3
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz \
+      | tar -C /usr/local -xzf - && \
+    ln -s /usr/local/go/bin/go /usr/local/bin/go && \
+    ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+ENV GOPATH=/home/node/go
+ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+
 # Install OpenClaw and mcporter globally from npm
 # renovate: datasource=npm depName=openclaw
 ARG OPENCLAW_VERSION=2026.3.2


### PR DESCRIPTION
## Contexte
Le backend TripKit est en cours de réécriture en Go (GORM + SQLite). Léa a besoin du toolchain Go pour builder et tester localement.

## Changements
- **Go 1.24.3** installé depuis le tarball officiel (pas de PPA/snap)
- **build-essential** pour CGo (`mattn/go-sqlite3` utilisé par GORM)
- `GOPATH=/home/node/go` (survit au volume mount)
- Symlinks `go` et `gofmt` dans `/usr/local/bin`

## Impact
- ~500 Mo supplémentaires sur l'image Docker (Go SDK + build-essential)
- Aucun impact sur les services existants
- Layer séparée pour le cache Docker

## Lié à
Réécriture backend TripKit : Node.js/Fastify → Go/chi/GORM (demandé par Baptiste)